### PR TITLE
check if x and y are defined, not truthy

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,12 +28,12 @@ function norm (q) {
         top: q.top,
         bottom: q.bottom
     };
-    if (p.left === undefined && q.x) p.left = q.x;
-    if (p.top === undefined && q.y) p.top = q.y;
+    if (p.left === undefined && q.x !== undefined) p.left = q.x;
+    if (p.top === undefined && q.y !== undefined) p.top = q.y;
     
     var w = q.width || 0, h = q.height || 0;
     
-    if (p.right === undefined && q.x) p.right = q.x + w;
-    if (p.bottom === undefined && q.y) p.bottom = q.y + h;
+    if (p.right === undefined && q.x !== undefined) p.right = q.x + w;
+    if (p.bottom === undefined && q.y !== undefined) p.bottom = q.y + h;
     return p;
 }

--- a/test/collide.js
+++ b/test/collide.js
@@ -6,6 +6,7 @@ test('collisions', function (t) {
     var b = { left: 6, top: 90, height: 20, width: 1 };
     var c = { x: -3, y: 20, width: 400, height: 300 };
     var d = { x: 2, y: 8 };
+    var e = { x: 0, y: 0, width: 10, height: 10};
     
     t.equal(collide(a,b), false, 'a,b -> false');
     t.equal(collide(a,c), true, 'a,c -> true');
@@ -13,5 +14,6 @@ test('collisions', function (t) {
     t.equal(collide(b,c), true, 'b,c -> true');
     t.equal(collide(b,d), false, 'b,d -> false');
     t.equal(collide(c,d), false, 'c,d -> false');
+    t.equal(collide(d,e), true, 'd,e -> true');
     t.end();
 });


### PR DESCRIPTION
Collision detection fails when `x` or `y` is `0`. Now specifically checking if they are defined. Also added a test to verify.